### PR TITLE
Fix for getting and setting ValueCan4 Industrial 

### DIFF
--- a/include/icsneo/device/tree/valuecan4/settings/valuecan4industrialsettings.h
+++ b/include/icsneo/device/tree/valuecan4/settings/valuecan4industrialsettings.h
@@ -12,7 +12,7 @@ class ValueCAN4IndustrialSettings : public IDeviceSettings {
 public:
 	ValueCAN4IndustrialSettings(std::shared_ptr<Communication> com) : IDeviceSettings(com, sizeof(valuecan4_industrial_settings_t)) {}
 	const CAN_SETTINGS* getCANSettingsFor(Network net) const override {
-		auto cfg = getStructurePointer<valuecan4_1_2_settings_t>();
+                auto cfg = getStructurePointer<valuecan4_industrial_settings_t>();
 		if(cfg == nullptr)
 			return nullptr;
 		switch(net.getNetID()) {
@@ -25,7 +25,7 @@ public:
 		}
 	}
 	const CANFD_SETTINGS* getCANFDSettingsFor(Network net) const override {
-		auto cfg = getStructurePointer<valuecan4_1_2_settings_t>();
+                auto cfg = getStructurePointer<valuecan4_industrial_settings_t>();
 		if(cfg == nullptr)
 			return nullptr;
 		switch(net.getNetID()) {


### PR DESCRIPTION
Possibly an typo. 
- Was not able to correctly determine or setup ValueCan4 Industrial settings. 
