### PR TITLE
Enhance Lin support

### DIFF
--- a/api/icsneocpp/event.cpp
+++ b/api/icsneocpp/event.cpp
@@ -116,6 +116,8 @@ static constexpr const char* A2B_MESSAGE_INCOMPLETE_FRAME = "At least one of the
 static constexpr const char* COREMINI_UPLOAD_VERSION_MISMATCH = "The version of the coremini engine on the device and the script uploaded are not the same.";
 static constexpr const char* DISK_NOT_CONNECTED = "The program tried to access a disk that is not connected.";
 static constexpr const char* UNEXPECTED_RESPONSE = "Received an unexpected or invalid response from the device.";
+static constexpr const char* LIN_SETTINGS_NOT_AVAILABLE = "LIN settings are not available for this device.";
+static constexpr const char* MODE_NOT_FOUND = "The mode was not found.";
 
 // Transport Errors
 static constexpr const char* FAILED_TO_READ = "A read operation failed.";
@@ -302,6 +304,10 @@ const char* APIEvent::DescriptionForType(Type type) {
 			return DISK_NOT_CONNECTED;
 		case Type::UnexpectedResponse:
 			return UNEXPECTED_RESPONSE;
+		case Type::LINSettingsNotAvailable:
+			return LIN_SETTINGS_NOT_AVAILABLE;
+		case Type::ModeNotFound:
+			return MODE_NOT_FOUND;
 		// Transport Errors
 		case Type::FailedToRead:
 			return FAILED_TO_READ;

--- a/examples/cpp/lin/src/LINExample.cpp
+++ b/examples/cpp/lin/src/LINExample.cpp
@@ -77,6 +77,37 @@ int main() {
 		}
 		std::cout << "OK" << std::endl;
 
+		std::cout << "\tGetting LIN Baudrate... ";
+		int64_t baud = device->settings->getBaudrateFor(icsneo::Network::NetID::LIN);
+		if(baud < 0)
+			std::cout << "FAIL" << std::endl;
+		else
+			std::cout << "OK, " << (baud) << "bit/s" << std::endl;
+
+		std::cout << "Enable LIN master resistor... ";
+		ret &= device->settings->setMasterResistorFor(icsneo::Network::NetID::LIN, true);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
+		std::cout << "Setting LIN2 to operate at " << baud << "bit/s... ";
+		ret = device->settings->setBaudrateFor(icsneo::Network::NetID::LIN2, baud);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
+		std::cout << "Setting LIN mode to NORMAL... ";
+		ret = device->settings->setLINModeFor(icsneo::Network::NetID::LIN, NORMAL_MODE);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
+		std::cout << "Setting LIN2 mode to NORMAL... ";
+		ret = device->settings->setLINModeFor(icsneo::Network::NetID::LIN2, NORMAL_MODE);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
+		std::cout << "Disable LIN2 master resistor... ";
+		ret &= device->settings->setMasterResistorFor(icsneo::Network::NetID::LIN2, false);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
+		std::cout << "Applying settings... ";
+		ret = device->settings->apply(true);
+		std::cout << (ret ? "OK" : "FAIL") << std::endl;
+
 		auto handler = device->addMessageCallback(std::make_shared<icsneo::MessageCallback>([&](std::shared_ptr<icsneo::Message> message) {
 			if(icsneo::Message::Type::Frame == message->type) {
 				auto frame = std::static_pointer_cast<icsneo::Frame>(message);
@@ -125,7 +156,7 @@ int main() {
 
 		// Go offline, stop sending and receiving traffic
 		auto shutdown = [&](){
-			device->removeMessageCallback(handler); 
+			device->removeMessageCallback(handler);
 			std::cout << "\tGoing offline... ";
 			ret = device->goOffline();
 			std::cout << (ret ? "OK" : "FAIL") << std::endl;

--- a/include/icsneo/api/event.h
+++ b/include/icsneo/api/event.h
@@ -104,6 +104,8 @@ public:
 		LiveDataEncoderError = 0x2050,
 		LiveDataDecoderError = 0x2051,
 		LiveDataNotSupported = 0x2052,
+		LINSettingsNotAvailable = 0x2053,
+		ModeNotFound = 0x2054,
 
 		// Transport Events
 		FailedToRead = 0x3000,

--- a/include/icsneo/device/idevicesettings.h
+++ b/include/icsneo/device/idevicesettings.h
@@ -544,7 +544,7 @@ enum
 };
 
 /* Mode in LIN_SETTINGS */
-enum
+enum LINMode
 {
 	SLEEP_MODE,
 	SLOW_MODE,
@@ -643,6 +643,7 @@ public:
 	static std::optional<uint16_t> CalculateGSChecksum(const std::vector<uint8_t>& settings, std::optional<size_t> knownSize = std::nullopt);
 	static CANBaudrate GetEnumValueForBaudrate(int64_t baudrate);
 	static int64_t GetBaudrateValueForEnum(CANBaudrate enumValue);
+	static bool ValidateLINBaudrate(int64_t baudrate);
 
 	IDeviceSettings(std::shared_ptr<Communication> com, size_t size) : com(com), report(com->report), structSize(size) {}
 	virtual ~IDeviceSettings() {}
@@ -700,6 +701,16 @@ public:
 		return reinterpret_cast<SWCAN_SETTINGS*>((void*)(settings.data() + (offset - settingsInDeviceRAM.data())));
 	}
 
+	virtual const LIN_SETTINGS* getLINSettingsFor(Network net) const { (void)net; return nullptr; }
+	LIN_SETTINGS* getMutableLINSettingsFor(Network net) {
+		if(disabled || readonly)
+			return nullptr;
+		const uint8_t* offset = (const uint8_t*)getLINSettingsFor(net);
+		if(offset == nullptr)
+			return nullptr;
+		return reinterpret_cast<LIN_SETTINGS*>((void*)(settings.data() + (offset - settingsInDeviceRAM.data())));
+	}
+
 	/**
 	 * Some devices have groupings of networks, where software
 	 * switchable termination can only be applied to one network
@@ -752,6 +763,53 @@ public:
 	 * will have been reported in icsneo::getLastError().
 	 */
 	bool setTerminationFor(Network net, bool enabled);
+
+	/**
+	 * Check whether software switchable master resistor is currently
+	 * enabled for a given network in the currently active device settings.
+	 *
+	 * Returns true if the call was successful, otherwise an error
+	 * will have been reported in icsneo::getLastError().
+	 */
+	std::optional<bool> isMasterResistorEnabledFor(Network net) const;
+
+	/**
+	 * Enable or disable software switchable master resistor for a given
+	 * network.
+	 *
+	 * Returns true if the call was successful, otherwise an error
+	 * will have been reported in icsneo::getLastError().
+	 */
+	bool setMasterResistorFor(Network net, bool resistor_on);
+
+	/**
+	 * Get LIN mode for a given network in the currently active device
+	 * settings.
+	 */
+	std::optional<enum LINMode> getLINModeFor(Network net) const;
+
+	/**
+	 * Set LIN mode for a given network.
+	 *
+	 * Returns true if the call was successful, otherwise an error
+	 * will have been reported in icsneo::getLastError().
+	 */
+	bool setLINModeFor(Network net, enum LINMode mode);
+
+	/**
+	 * Get number of bit delays between Master ID and first Slave byte for
+	 * a given network in the currently active device settings.
+	 */
+	std::optional<uint8_t> getLINMasterSlaveIntervalFor(Network net) const;
+
+	/**
+	 * Set number of bit delays between Master ID and first Slave byte for
+	 * a given network
+	 *
+	 * Returns true if the call was successful, otherwise an error
+	 * will have been reported in icsneo::getLastError().
+	 */
+	bool setLINMasterSlaveIntervalFor(Network net, uint8_t bits);
 
 	const void* getRawStructurePointer() const { return settingsInDeviceRAM.data(); }
 	void* getMutableRawStructurePointer() { return settings.data(); }

--- a/include/icsneo/device/tree/etherbadge/etherbadgesettings.h
+++ b/include/icsneo/device/tree/etherbadge/etherbadgesettings.h
@@ -88,6 +88,17 @@ public:
 				return nullptr;
 		}
 	}
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<etherbadge_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/neovifire/neovifiresettings.h
+++ b/include/icsneo/device/tree/neovifire/neovifiresettings.h
@@ -131,6 +131,23 @@ public:
 				return nullptr;
 		}
 	}
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<neovifire_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			case Network::NetID::LIN2:
+				return &(cfg->lin2);
+			case Network::NetID::LIN3:
+				return &(cfg->lin3);
+			case Network::NetID::LIN4:
+				return &(cfg->lin4);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/neovifire2/neovifire2settings.h
+++ b/include/icsneo/device/tree/neovifire2/neovifire2settings.h
@@ -209,6 +209,28 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<neovifire2_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			case Network::NetID::LIN2:
+				return &(cfg->lin2);
+			case Network::NetID::LIN3:
+				return &(cfg->lin3);
+			case Network::NetID::LIN4:
+				return &(cfg->lin4);
+			case Network::NetID::LIN5:
+				return &(cfg->lin5);
+			case Network::NetID::LIN6:
+				return &(cfg->lin6);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<neovifire2_settings_t>();

--- a/include/icsneo/device/tree/neovifire3/neovifire3settings.h
+++ b/include/icsneo/device/tree/neovifire3/neovifire3settings.h
@@ -229,6 +229,32 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<neovifire3_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			case Network::NetID::LIN2:
+				return &(cfg->lin2);
+			case Network::NetID::LIN3:
+				return &(cfg->lin3);
+			case Network::NetID::LIN4:
+				return &(cfg->lin4);
+			case Network::NetID::LIN5:
+				return &(cfg->lin5);
+			case Network::NetID::LIN6:
+				return &(cfg->lin6);
+			case Network::NetID::LIN7:
+				return &(cfg->lin7);
+			case Network::NetID::LIN8:
+				return &(cfg->lin8);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<neovifire3_settings_t>();

--- a/include/icsneo/device/tree/neovifire3flexray/neovifire3flexraysettings.h
+++ b/include/icsneo/device/tree/neovifire3flexray/neovifire3flexraysettings.h
@@ -212,6 +212,24 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<neovifire3flexray_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			case Network::NetID::LIN2:
+				return &(cfg->lin2);
+			case Network::NetID::LIN3:
+				return &(cfg->lin3);
+			case Network::NetID::LIN4:
+				return &(cfg->lin4);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<neovifire3flexray_settings_t>();

--- a/include/icsneo/device/tree/neovired2/neovired2settings.h
+++ b/include/icsneo/device/tree/neovired2/neovired2settings.h
@@ -170,6 +170,20 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<neovired2_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			case Network::NetID::LIN2:
+				return &(cfg->lin2);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<neovired2_settings_t>();

--- a/include/icsneo/device/tree/rada2b/rada2bsettings.h
+++ b/include/icsneo/device/tree/rada2b/rada2bsettings.h
@@ -121,6 +121,18 @@ public:
 		}
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<rada2b_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
+
 	TDMMode getTDMMode(RADA2BDevice device) const {
 		auto cfg = getStructurePointer<rada2b_settings_t>();
 		auto &deviceSettings = device == RADA2BDevice::Monitor ? cfg->a2b_monitor : cfg->a2b_node;

--- a/include/icsneo/device/tree/radgalaxy/radgalaxysettings.h
+++ b/include/icsneo/device/tree/radgalaxy/radgalaxysettings.h
@@ -170,6 +170,18 @@ public:
 				return nullptr;
 		}
 	}
+
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radgalaxy_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/radgigastar/radgigastarsettings.h
+++ b/include/icsneo/device/tree/radgigastar/radgigastarsettings.h
@@ -149,6 +149,18 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radgigastar_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<radgigastar_settings_t>();

--- a/include/icsneo/device/tree/radjupiter/radjupitersettings.h
+++ b/include/icsneo/device/tree/radjupiter/radjupitersettings.h
@@ -118,6 +118,17 @@ public:
 				return nullptr;
 		}
 	}
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radjupiter_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/radmars/radmarssettings.h
+++ b/include/icsneo/device/tree/radmars/radmarssettings.h
@@ -170,6 +170,18 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radmars_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<radmars_settings_t>();

--- a/include/icsneo/device/tree/radpluto/radplutosettings.h
+++ b/include/icsneo/device/tree/radpluto/radplutosettings.h
@@ -104,6 +104,18 @@ public:
 				return nullptr;
 		}
 	}
+
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radpluto_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/radstar2/radstar2settings.h
+++ b/include/icsneo/device/tree/radstar2/radstar2settings.h
@@ -99,6 +99,18 @@ public:
 				return nullptr;
 		}
 	}
+
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<radstar2_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/valuecan4/settings/valuecan4-2elsettings.h
+++ b/include/icsneo/device/tree/valuecan4/settings/valuecan4-2elsettings.h
@@ -45,6 +45,18 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<valuecan4_4_2el_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<valuecan4_4_2el_settings_t>();

--- a/include/icsneo/device/tree/valuecan4/settings/valuecan4-4-2elsettings.h
+++ b/include/icsneo/device/tree/valuecan4/settings/valuecan4-4-2elsettings.h
@@ -37,6 +37,18 @@ public:
 				return nullptr;
 		}
 	}
+
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<valuecan4_4_2el_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
 };
 
 }

--- a/include/icsneo/device/tree/valuecan4/settings/valuecan4-4settings.h
+++ b/include/icsneo/device/tree/valuecan4/settings/valuecan4-4settings.h
@@ -59,6 +59,18 @@ public:
 		};
 	}
 
+	const LIN_SETTINGS* getLINSettingsFor(Network net) const override {
+		auto cfg = getStructurePointer<valuecan4_4_2el_settings_t>();
+		if(cfg == nullptr)
+			return nullptr;
+		switch(net.getNetID()) {
+			case Network::NetID::LIN:
+				return &(cfg->lin1);
+			default:
+				return nullptr;
+		}
+	}
+
 protected:
 	ICSNEO_UNALIGNED(const uint64_t*) getTerminationEnables() const override {
 		auto cfg = getStructurePointer<valuecan4_4_2el_settings_t>();


### PR DESCRIPTION
Add APIs to set LIN baudrate, mode, master resistor. Add this API calls to LIN example.

> NOTE: tested only on EtherBADGE and RAD-Jupiter, but support is added to all LIN-capable devices.