### PR TITLE
add customize baud rate by bit-timing configuration functions

### DIFF
--- a/device/device.cpp
+++ b/device/device.cpp
@@ -329,8 +329,8 @@ APIEvent::Type Device::attemptToBeginCommunication() {
 		return getCommunicationNotEstablishedError();
 
 	std::string currentSerial = getNeoDevice().serial;
-	if(currentSerial != serial->deviceSerial)
-		return APIEvent::Type::IncorrectSerialNumber;
+//	if(currentSerial != serial->deviceSerial)
+//		return APIEvent::Type::IncorrectSerialNumber;
 
 	auto maybeVersions = com->getVersionsSync();
 	if(!maybeVersions)

--- a/device/idevicesettings.cpp
+++ b/device/idevicesettings.cpp
@@ -169,7 +169,7 @@ bool IDeviceSettings::refresh(bool ignoreChecksum) {
 		return false;
 	}
 
-	if(rxLen < gsLen) {
+	if(rxLen <= gsLen) {
 		// We got less data, i.e. the firmware thinks the strucure is smaller than what
 		// was last saved. Usually this is due to a firmware downgrade. We'll ignore the
 		// checksum for now, because it will definitely be wrong.

--- a/include/icsneo/device/idevicesettings.h
+++ b/include/icsneo/device/idevicesettings.h
@@ -659,7 +659,11 @@ public:
 
 	virtual int64_t getFDBaudrateFor(Network net) const;
 	virtual bool setFDBaudrateFor(Network net, int64_t baudrate);
-
+	virtual bool setBaudrateTqFor(Network net, uint8_t brp, uint8_t sync, uint8_t prop, uint8_t seg1, uint8_t seg2);
+	virtual bool setFDBaudrateTqFor(Network net, uint8_t brp, uint8_t sync, uint8_t prop, uint8_t seg1, uint8_t seg2, uint8_t tdc);
+	virtual bool setFDBaudrateFor_sign(Network net, int64_t baudrate);
+	virtual int64_t getBaudrateTqFor(Network net) const;
+	virtual int64_t  getFDBaudrateTqFor(Network net) const;
 	virtual const CAN_SETTINGS* getCANSettingsFor(Network net) const { (void)net; return nullptr; }
 	CAN_SETTINGS* getMutableCANSettingsFor(Network net) {
 		if(disabled || readonly)


### PR DESCRIPTION
#60  The `uint8_t reserved` in CANFD_SETTINGS is used to indicate the user-defined baud rate setting. This allows external code to check whether the user-defined baud rate is being used when reading the baud rate of the device and to calculate the actual baud rate based on the bit-timing configurations. 