### PR TITLE
Fixed Npcap related errors in PCAPDLL::PCAPDLL()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(LIBICSNEO_BUILD_ICSNEOC "Build dynamic C library" ON)
 option(LIBICSNEO_BUILD_ICSNEOC_STATIC "Build static C library" ON)
 option(LIBICSNEO_BUILD_ICSNEOLEGACY "Build icsnVC40 compatibility library" ON)
 option(LIBICSNEO_BUILD_ICSNEOLEGACY_STATIC "Build static icsnVC40 compatibility library" ON)
-set(LIBICSNEO_NPCAP_INCLUDE_DIR "" CACHE STRING "Npcap include directory; set to build with Npcap")
+set(LIBICSNEO_NPCAP_INCLUDE_DIR "C:/Users/Vit/source/repos/npcap-sdk-1.13/Include" CACHE STRING "Npcap include directory; set to build with Npcap") 
 
 # Device Drivers
 # You almost certainly don't want firmio for your build,

--- a/platform/windows/internal/pcapdll.cpp
+++ b/platform/windows/internal/pcapdll.cpp
@@ -34,9 +34,12 @@ PCAPDLL::PCAPDLL()
 	int len = GetSystemDirectory(dllPath, 480); // be safe
 	if (len) {
 		_tcscat_s(dllPath, 512, TEXT("\\Npcap"));
-		cookie = AddDllDirectory(dllPath);
+		WCHAR dllPath_w[512] = { 0 };
+		if (mbstowcs(dllPath_w, dllPath, 512)) {
+			cookie = AddDllDirectory(dllPath_w);
+		}
 	}
-	dll = LoadLibraryEx(TEXT("wpcap.dll"), nullptr, LOAD_LIBRARY_SEARCH_USER_DIRS);
+	dll = LoadLibraryEx(TEXT("wpcap.dll"), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 	if (cookie)
 		RemoveDllDirectory(cookie);


### PR DESCRIPTION
PCAPDLL constructor has alternative path for Npcap libraries when libicneo is build with LIBICSNEO_NPCAP_INCLUDE_DIR. There are two bugs in this path:

dllPath variable used for AddDllDirectory() is of type TCHAR [] but AddDllDirectory() expects LPWSTR so the string needs to be converted to wide string first.
LoadLibraryEx() uses LOAD_LIBRARY_SEARCH_USER_DIRS so it is unable to load other dependent modules. Proper flag should be LOAD_LIBRARY_SEARCH_DEFAULT_DIRS which includes both user and system paths to search.
