### PR TITLE
EthernetPacketizer: do a size check on incoming bytestream

### DIFF
--- a/communication/ethernetpacketizer.cpp
+++ b/communication/ethernetpacketizer.cpp
@@ -133,6 +133,10 @@ EthernetPacketizer::EthernetPacket::EthernetPacket(const uint8_t* data, size_t s
 
 int EthernetPacketizer::EthernetPacket::loadBytestream(const std::vector<uint8_t>& bytestream) {
 	errorWhileDecodingFromBytestream = 0;
+	if (bytestream.size() < 24) {
+		errorWhileDecodingFromBytestream = 1;
+		return errorWhileDecodingFromBytestream;
+	}
 	for(size_t i = 0; i < 6; i++)
 		destMAC[i] = bytestream[i];
 	for(size_t i = 0; i < 6; i++)


### PR DESCRIPTION
An incoming bytestream can be less than 24 bytes, leading to exceptions when accessing its data (or allocating the vector for its payload). Perform a size check before trying to decode the bytestream and discard invalid incoming streams.