### PR TITLE
darwin: fix CDCACM device detection on macOS 12+

### DIFF
--- a/platform/posix/darwin/cdcacmdarwin.cpp
+++ b/platform/posix/darwin/cdcacmdarwin.cpp
@@ -108,8 +108,9 @@ void CDCACM::Find(std::vector<FoundDevice>& found) {
 			releasers.emplace_back(parent);
 			current = parent;
 			// On old macOSes, IOUSBDevice is the type of the class we want
-			// On newer macOSes, IOUSBDevice may further be subclassed as IOUSBHostDevice
-			if(IOObjectConformsTo(parent, kIOUSBDeviceClassName)) {
+			// On macOS 12+, IOUSBHostDevice is the main USB device class (separate hierarchy from IOUSBDevice)
+			if(IOObjectConformsTo(parent, kIOUSBDeviceClassName) ||
+			   IOObjectConformsTo(parent, "IOUSBHostDevice")) {
 				usb = parent;
 				break;
 			}


### PR DESCRIPTION
On macOS 12 and later, Apple replaced IOUSBDevice with IOUSBHostDevice in the USB host stack. When walking the IORegistry parent chain to find the USB device providing a serial port, the existing code only checked IOObjectConformsTo(parent, kIOUSBDeviceClassName). On macOS 12+, this check fails because the USB device node conforms to IOUSBHostDevice instead.

Fix by also checking IOObjectConformsTo(parent, "IOUSBHostDevice"), so CDCACM device discovery works on both old and new macOS.

Verified on macOS 26 (Tahoe, arm64) with a ValueCAN 4-2 (V2D805).