### PR TITLE
servd: default Enabled() to false when LIBICSNEO_USE_SERVD is unset

### DIFF
--- a/platform/servd.cpp
+++ b/platform/servd.cpp
@@ -20,7 +20,7 @@ bool Servd::Enabled() {
 	#ifdef _MSC_VER
 	#pragma warning(pop)
 	#endif
-	return enabled ? enabled[0] == '1' : true;
+	return enabled ? enabled[0] == '1' : false;
 }
 
 std::vector<std::string> split(const std::string_view& str, char delim = ' ') {


### PR DESCRIPTION
Previously, Servd::Enabled() returned true by default when the LIBICSNEO_USE_SERVD environment variable was not set. This caused DeviceFinder::FindAll() to take the Servd::Find() path and skip all direct transport discovery (CDCACM, DXX, PCAP, etc.) even when no servd daemon is running, silently returning zero devices.

The intended behavior is opt-in: users who want to use servd should explicitly set LIBICSNEO_USE_SERVD=1. Change the default to false so direct device discovery works out of the box.

LIBICSNEO_USE_SERVD=1 continues to enable servd as before.